### PR TITLE
Change the way we get the section for the event

### DIFF
--- a/ahoy.js
+++ b/ahoy.js
@@ -208,7 +208,7 @@
       id: $target.attr("id"),
       "class": $target.attr("class"),
       page: page(),
-      section: $target.closest("*[data-section]").data("section")
+      section: $target.closest("*[data-section]").attr("data-section")
     };
   }
 


### PR DESCRIPTION
Instead of using jQuery's `.data` function. Use the `.attr` function to prevent caching issue with elements that their data-section is changed dynamically.